### PR TITLE
Add otterbucket app

### DIFF
--- a/otterBucket/otterBucket/urls.py
+++ b/otterBucket/otterBucket/urls.py
@@ -14,8 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 
 urlpatterns = [
+    path('', include('otterbucket_app.urls')),
     path('admin/', admin.site.urls),
 ]

--- a/otterBucket/otterbucket_app/urls.py
+++ b/otterBucket/otterbucket_app/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    #the empty string is the end of the URL
+    #the views.index is the function in in views.py to go to
+    #name is the tab name(if you hover over the tab in google chrome it will say the name)
+    path('', views.index, name='index'),
+    path('list', views.list, name='list')
+]

--- a/otterBucket/otterbucket_app/views.py
+++ b/otterBucket/otterbucket_app/views.py
@@ -1,3 +1,10 @@
 from django.shortcuts import render
+from django.http import HttpResponse
 
 # Create your views here.
+# index is the name used in urls.py to call this function
+def index(request):
+    return HttpResponse("<h1>This is were you would put a view file</h1><a href='/list'>to list</a>")
+
+def list(request):
+    return HttpResponse("<a href = '/'>Back to index</a><h1>this is a list</h1>")


### PR DESCRIPTION
this update should allow us to put views into the otterbucket_app folder. the base url '' in otterbucket/urls.py will use urls in otterbucket_app/urls.py. I added some example views to the otterbucket/views.py to show that it is working. 